### PR TITLE
Add a feature to change the issue status with commit messages (fix, close)

### DIFF
--- a/app/src/main/java/jp/kazamori/github/actions/backlog/cli/BacklogClientCli.java
+++ b/app/src/main/java/jp/kazamori/github/actions/backlog/cli/BacklogClientCli.java
@@ -1,5 +1,6 @@
 package jp.kazamori.github.actions.backlog.cli;
 
+import com.nulabinc.backlog4j.Issue;
 import com.nulabinc.backlog4j.api.option.AddIssueCommentParams;
 import com.nulabinc.backlog4j.api.option.UpdateIssueParams;
 import com.typesafe.config.Config;
@@ -41,6 +42,11 @@ public class BacklogClientCli implements Runnable {
             description = "set custom field name")
     private Optional<String> customField;
 
+    @CommandLine.Option(names = "--fixed",
+            description = "change issue status to be fixed",
+            defaultValue = "false")
+    private boolean isFixed;
+
     @Override
     public void run() {
         val client = BacklogClientUtil.createClient(this.config);
@@ -65,6 +71,14 @@ public class BacklogClientCli implements Runnable {
         if (customField.isPresent()) {
             val customFieldName = this.customField.get();
             util.updateCustomFieldOfIssue(issue, customFieldName, this.issueComment.get());
+        }
+
+        if (isFixed) {
+            logger.info(" * fixed: {}", isFixed);
+            val params = new UpdateIssueParams(this.issueId)
+                    .status(Issue.StatusType.Resolved);
+            val updated = client.updateIssue(params);
+            logger.info("Updated issue status: {} -> {}", issue.getStatus().getName(), updated.getStatus().getName());
         }
     }
 

--- a/app/src/main/java/jp/kazamori/github/actions/backlog/entity/CommitInfo.java
+++ b/app/src/main/java/jp/kazamori/github/actions/backlog/entity/CommitInfo.java
@@ -1,0 +1,15 @@
+package jp.kazamori.github.actions.backlog.entity;
+
+import com.nulabinc.backlog4j.Issue;
+import jp.kazamori.github.actions.backlog.entity.github.PushEventCommit;
+import lombok.Value;
+
+import java.util.List;
+import java.util.Optional;
+
+@Value
+public class CommitInfo {
+    private String issueId;
+    private List<PushEventCommit> commits;
+    private Optional<Issue.StatusType> status;
+}


### PR DESCRIPTION
I added #2 to integrate backlog with commits. Additionally, it's useful to change the backlog issue status by a commit message.

* fix, fixes, fixed -> Resolved
* close, closes, closed -> Closed

For example, you can change the issue status like this.

```
fix TEST-1
```

```
closed TEST-1
```

## Reference

* https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword